### PR TITLE
Addfantasypoints

### DIFF
--- a/nba-fantasy/src/Components/Sports/TeamDisplay.js
+++ b/nba-fantasy/src/Components/Sports/TeamDisplay.js
@@ -1,19 +1,19 @@
-import React from 'react'
+import React from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faPenSquare} from '@fortawesome/free-solid-svg-icons';
+import { faPenSquare } from '@fortawesome/free-solid-svg-icons';
 import { faTrash } from '@fortawesome/free-solid-svg-icons';
 
-export const TeamDisplay = ({task,deletePlayer,editTeam}) => {
+export const TeamDisplay = ({ task, deletePlayer, editTeam }) => {
   return (
-    <>
     <div className='TeamDisplay'>
-      <p>{task.task}</p> {/* Assuming task is an object with a task property */}
+      <p>
+        {task.task} - Points: {task.points}
+      </p>
       <div>
-        <FontAwesomeIcon icon={faPenSquare} onClick={() => editTeam(task.id)}/>
-        <FontAwesomeIcon icon={faTrash} onClick={() => deletePlayer(task.id)}/>
+        <FontAwesomeIcon icon={faPenSquare} onClick={() => editTeam(task.id)} />
+        <FontAwesomeIcon icon={faTrash} onClick={() => deletePlayer(task.id)} />
       </div>
     </div>
-    </>
   );
 };
 

--- a/nba-fantasy/src/Components/Sports/TeamWrapper.js
+++ b/nba-fantasy/src/Components/Sports/TeamWrapper.js
@@ -3,17 +3,37 @@ import { Team } from './Team';
 import { v4 as uuidv4 } from 'uuid';
 import { TeamDisplay } from './TeamDisplay';
 import {EditTeam} from './EditTeam';
+import axios from '../api/axios'
 
 uuidv4();
 
 export const TeamWrapper = () => {
   const [teams, setTeam] = useState([])
+  const [message, setMessage] = useState('');
 
-  const addTeam = (player )=> {
-    setTeam([...teams, { id: uuidv4(), task: player, dropped: false, isEditing: false }]);
-  }
+
+
+  
+
+  const addTeam = async (player) => {
+
+    setMessage('');
+    const fantasyPoints = await fetchPointsForPlayer(player);
+  
+    // Check if player exists (assuming 0 points indicates non-existence)
+    if (fantasyPoints !== 0) {
+      const newPlayer = { id: uuidv4(), task: player, points: fantasyPoints, dropped: false, isEditing: false };
+      setTeam(prevTeams => [...prevTeams, newPlayer]);
+    } else {
+      // Optionally, set a message indicating the player does not exist
+      setMessage(`Player ${player} not found or has no data available.`);
+    }
+  };
+  
+  
 
   const deletePlayer = (id) => {
+  
     setTeam(teams.filter(player => player.id !== id))
   }
 
@@ -26,9 +46,60 @@ export const TeamWrapper = () => {
     setTeam(teams.map(player=>player.id === id? {...player,task,isEditing: !player.isEditing} :player ))
   }
 
+  const fetchPointsForPlayer = async (playerName) => {
+    
+    try{
+      const response = await axios.get(`https://www.balldontlie.io/api/v1/players?search=${playerName}`);
+      
+  
+      const playerId = response.data.data[0].id;
+      console.log(playerId);
+  
+      const stats = await axios.get(`https://www.balldontlie.io/api/v1/season_averages?season=2023&player_ids[]=${playerId}`);
+      
+
+      
+
+     
+      const points = (stats.data.data[0].pts) * 1;
+      const assists = (stats.data.data[0].ast) * 1.5;
+      const rebounds = (stats.data.data[0].reb) * 1.2;
+      const steals = (stats.data.data[0].stl) * 3;
+      const blocks = (stats.data.data[0].blk) * 3;
+      const turnovers = (stats.data.data[0].turnover) * -1;
+
+      
+
+
+      const fanstasypoints = points + assists + rebounds + steals + blocks + turnovers;
+      const value  = Math.round(10*fanstasypoints)/10; 
+      
+      
+  
+      return value;
+    }catch (error) {
+      console.error('Error fetching points:', error);
+      setMessage(`No data found for player: Reenter Proper Name`);
+      return 0;
+    }
+    
+  };
+
+  const getTotalTeamPoints = () => {
+    const total = teams.reduce((total, player) => total + player.points, 0);
+    return Math.round(total * 10) / 10;
+  };
+
+
+ 
+
+
   return (
     <>
       <h1>Your Team</h1>
+      {message && <div className="alert">{message}</div>} {/* Display the message */}
+      <div>Total Points: {getTotalTeamPoints()}</div> {/* Display total points */}
+
       <Team addTeam={addTeam} />
 
       {teams.map((player, index) => (
@@ -40,6 +111,8 @@ export const TeamWrapper = () => {
         )
         
       ))}
+
+
       
     
     </>


### PR DESCRIPTION
TeamWrapper.js
- added a message for everything a user tries to add a player who is not playing the 2023 season 
- when you add a player to a team you are also adding the amount of fantasy points they have using the Ball Not Lie API
- the fetchPointsForPlayer function calls https://www.balldontlie.io/api/v1/players?search=${playerName}, which gets the player's id the user inputted. The ID is then used in https://www.balldontlie.io/api/v1/season_averages?season=2023&player_ids[]=${playerId}, to get a json object with the seasons stats
- the fantasy points are one value, which you get by getting the player's individual stats for points, assists, rebounds, steals, blocks, turnovers, and adding a multiplayer for each stat. all of which are added together for the player's fantasy points
- getTotalTeamPoints displays the total fantasy point of the whole team 